### PR TITLE
add ability to fully "render" the protobuf object in the response from local_rpc

### DIFF
--- a/lib/protobuf/rspec/helpers.rb
+++ b/lib/protobuf/rspec/helpers.rb
@@ -1,4 +1,13 @@
+require 'rspec/core'
 require 'protobuf/rpc/rpc.pb'
+
+::RSpec.configure do |config|
+  config.add_setting :protobuf_raw_response, :default => false
+
+  def config.protobuf_raw_responses
+    self.protobuf_raw_response = true
+  end
+end
 
 # RSpec Helpers designed to give you mock abstraction of client or service layer.
 # Require as protobuf/rspec/helpers and include into your running RSpec configuration.
@@ -20,6 +29,20 @@ module Protobuf
       end
 
       module ClassMethods
+
+        def metadata_for_protobuf_rspec
+          metadata[:protobuf_rspec] = metadata[:protobuf_rspec] ? metadata[:protobuf_rspec].dup : {}
+        end
+
+        def protobuf_raw_responses(true_or_false = true)
+          metadata_for_protobuf_rspec[:protobuf_raw_response] = true_or_false
+        end
+
+        def protobuf_raw_responses?
+          metadata_for_protobuf_rspec.fetch(:protobuf_raw_response) do 
+            ::RSpec.configuration.protobuf_raw_response?
+          end
+        end
 
         # Set the service subject. Use this method when the described_class is
         # not the class you wish to use with methods like local_rpc. In t
@@ -52,6 +75,10 @@ module Protobuf
       end
 
       module InstanceMethods
+
+        def protobuf_raw_responses?
+          self.class.protobuf_raw_responses?
+        end
 
         def subject_service
           self.class.subject_service
@@ -96,26 +123,33 @@ module Protobuf
         #
         # @param [Symbol, String] method a symbol or string denoting the method to call.
         # @param [Protobuf::Message or Hash] request the request message of the expected type for the given method.
-        # @param [String] a string message indicating an rpc_failed expectation.
         # @param [block] optionally provide a block which will be yielded the service instance just prior to invoking the rpc method.
         # @return [Protobuf::Service] the service instance post-calling the rpc method.
-        def local_rpc(rpc_method, request, expected_error = nil)
+        def local_rpc(rpc_method, request, raw_response = false)
           request = subject_service.rpcs[rpc_method].request_type.new(request) if request.is_a?(Hash)
-          service = subject_service.new(rpc_method, request.serialize_to_string)
 
-          if block_given?
-            $stderr.puts '[Warning] Ignoring error expectation %s due to given block' % expected_error unless expected_error.blank?
-            yield(service)
+          if raw_response || protobuf_raw_responses? || request.serialize_to_string.empty?
+            service = subject_service.new(rpc_method, request.serialize_to_string)
+
+            yield(service) if block_given?
+
+            service.__send__(rpc_method)
+            return service
           else
-            if expected_error.blank?
-              service.should_not_receive(:rpc_failed)
-            else
-              service.should_receive(:rpc_failed).with(expected_error)
-            end
+            return __dispatch_service_call__(rpc_method, request)
           end
+        end
 
-          service.__send__(rpc_method)
-          service
+        def __dispatch_service_call__(rpc_method, request)
+          request_params = { 
+            :service_name => subject_service.to_s, 
+            :method_name => rpc_method.to_s, 
+            :request_proto => request.serialize_to_string
+          }
+
+          rpc_request = ::Protobuf::Socketrpc::Request.new(request_params)
+          dispatcher = ::Protobuf::Rpc::ServiceDispatcher.new(rpc_request)
+          dispatcher.invoke!
         end
 
         # Provides backwards compatability to bridge to the new local_rpc usage.


### PR DESCRIPTION
This also makes fully "rendering" the default behavior.  I discovered while writing that some of the old behavior of the method does not actually mimic the behavior of protobuf, the most notable exception was testing with an "empty" probobuf request, this actually throws an error prior to dispatching to the service method and the tested behavior is not the actual behavior.

You can override the "rendering" behavior by putting `protobuf_raw_responses` in any of the context blocks and for that context the raw message will be returned (or rather the service with the `response` attribute populated as before).
