### PR TITLE
...ass for an endpoint.

### DIFF
--- a/lib/protobuf/rspec/helpers.rb
+++ b/lib/protobuf/rspec/helpers.rb
@@ -235,7 +235,7 @@ module Protobuf
         #     request_class(:create) # => UserRequest
         #
         def request_class(endpoint)
-          described_class.rpcs[endpoint].request_type
+          subject_service.rpcs[endpoint].request_type
         end
 
         # Returns the response class for a given endpoint of the described class
@@ -245,7 +245,7 @@ module Protobuf
         #     response_class(:create) # => UserResponse
         #
         def response_class(endpoint)
-          described_class.rpcs[endpoint].response_type
+          subject_service.rpcs[endpoint].response_type
         end
       end
     end


### PR DESCRIPTION
That title doesn't make sense, but it's what Github decided to put in there so I left it. What it should have said was:

> Added a couple of helper methods for getting the request and response class for an endpoint.

This is useful for building a request without having to reference the whole class.
