### PR TITLE
add back yielding dispatcher service before invocation if block_given

### DIFF
--- a/lib/protobuf/rspec/helpers.rb
+++ b/lib/protobuf/rspec/helpers.rb
@@ -109,6 +109,8 @@ module Protobuf
           outer_request = ::Protobuf::Socketrpc::Request.new(outer_request_params)
           dispatcher = ::Protobuf::Rpc::ServiceDispatcher.new(outer_request)
 
+          yield(dispatcher.service) if block_given?
+
           dispatcher.invoke!
         end
 


### PR DESCRIPTION
After working on the specs in one of the services I realize this is the only way to get stubs set on the service for failure states and pagination expectations 
